### PR TITLE
Prevent the control clear patch from blocking ctrl-u

### DIFF
--- a/slock.c
+++ b/slock.c
@@ -393,13 +393,11 @@ readpw(Display *dpy, struct xrandr *rr, struct lock **locks, int nscreens,
 			#endif // MEDIAKEYS_PATCH
 			default:
 				#if CONTROLCLEAR_PATCH
-				if (controlkeyclear && iscntrl((int)buf[0]))
+				if (controlkeyclear && iscntrl((int)buf[0]) && !num)
 					continue;
-				if (num && (len + num < sizeof(passwd)))
-				#else
+				#endif // CONTROLCLEAR_PATCH
 				if (num && !iscntrl((int)buf[0]) &&
 				    (len + num < sizeof(passwd)))
-				#endif // CONTROLCLEAR_PATCH
 				{
 					memcpy(passwd + len, buf, num);
 					len += num;


### PR DESCRIPTION
The control clear patch is not compatible with the latest ctrl-u feature because it blocks all ctrl shortcuts. This fix ensures that the patch is active only when the ctrl key is pressed without any other keys.

Note that the patch is also active when the shift or alt key is pressed without any other keys. This is an undocumented feature of this patch and is caused by the iscntrl function, which returns true if the ascii value is zero.