### PR TITLE
Adding support for alternate colors to get keyboard feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ slock tool, how to install it and how it works.
 
 ### Changelog:
 
+2026-01-03 - Added the alternate colors patch
+
 2025-11-15 - Added the visual unlock patch
 
 2022-03-28 - Added the background image patch
@@ -49,6 +51,10 @@ slock tool, how to install it and how it works.
    - [alpha](https://github.com/khuedoan/slock)
       - enables transparency for slock
       - intended to be combined with a compositor that can blur the transparent background
+
+   - [alternate_colors](https://tools.suckless.org/slock/patches/alternate-colors)
+      - Toggle screen color between two shades of blue during password input to get some feedback
+      - Alternative to the random boxes drawing to get keyboard feedback
 
    - [auto-timeout](https://tools.suckless.org/slock/patches/auto-timeout/)
       - allows for a command to be executed after a specified time of inactivity

--- a/config.def.h
+++ b/config.def.h
@@ -8,6 +8,9 @@ static const char *colorname[NUMCOLS] = {
 	#endif // DWM_LOGO_PATCH
 	[INIT] =   "black",     /* after initialization */
 	[INPUT] =  "#005577",   /* during input */
+	#if ALTERNATE_COLORS_PATCH
+	[INPUT_ALT] = "#227799", /* during input, second color */
+	#endif // ALTERNATE_COLORS_PATCH
 	[FAILED] = "#CC3333",   /* wrong password */
 	#if CAPSCOLOR_PATCH
 	[CAPS] =   "red",       /* CapsLock on */

--- a/patches.def.h
+++ b/patches.def.h
@@ -16,6 +16,12 @@
  */
 #define ALPHA_PATCH 0
 
+/* Toggle screen color between two shades of blue during password input to get some feedback,
+ * an option when not wanting to add random squares for a similar purpose
+ * https://tools.suckless.org/slock/patches/alternate-colors
+ */
+#define ALTERNATE_COLORS_PATCH 0
+
 /* This patch allows for a command to be executed after a specified time of inactivity.
  * https://tools.suckless.org/slock/patches/auto-timeout/
  */

--- a/slock.c
+++ b/slock.c
@@ -70,6 +70,9 @@ enum {
 	#endif // DWM_LOGO_PATCH
 	INIT,
 	INPUT,
+	#if ALTERNATE_COLORS_PATCH
+	INPUT_ALT,
+	#endif // ALTERNATE_COLORS_PATCH
 	FAILED,
 	#if CAPSCOLOR_PATCH
 	CAPS,
@@ -417,9 +420,17 @@ readpw(Display *dpy, struct xrandr *rr, struct lock **locks, int nscreens,
 				break;
 			}
 			#if CAPSCOLOR_PATCH
+			#if ALTERNATE_COLORS_PATCH
+			color = len ? (caps ? CAPS : (len%2 ? INPUT : INPUT_ALT)) : (failure || failonclear ? FAILED : INIT);
+			#else
 			color = len ? (caps ? CAPS : INPUT) : (failure || failonclear ? FAILED : INIT);
+			#endif // ALTERNATE_COLORS_PATCH
+			#else
+			#if ALTERNATE_COLORS_PATCH
+			color = len ? (len%2 ? INPUT : INPUT_ALT) : ((failure || failonclear) ? FAILED : INIT);
 			#else
 			color = len ? INPUT : ((failure || failonclear) ? FAILED : INIT);
+			#endif  // ALTERNATE_COLORS_PATCH
 			#endif // CAPSCOLOR_PATCH
 			if (running && oldc != color) {
 				for (screen = 0; screen < nscreens; screen++) {
@@ -714,6 +725,7 @@ main(int argc, char **argv) {
 		die("slock: crypt: %s\n", strerror(errno));
 	#endif // PAMAUTH_PATCH
 
+
 	if (!(dpy = XOpenDisplay(NULL)))
 		die("slock: cannot open display\n");
 
@@ -795,6 +807,7 @@ main(int argc, char **argv) {
 
 	/* everything is now blank. Wait for the correct password */
 	readpw(dpy, &rr, locks, nscreens, hash);
+
 	#if DPMS_PATCH
 	/* reset DPMS values to inital ones */
 	DPMSSetTimeouts(dpy, standby, suspend, off);


### PR DESCRIPTION
The [alternate-colors](https://tools.suckless.org/slock/patches/alternate-colors) patch is a nice alternative to drawing random boxes, to get some feedback while using the keyboard to provide the password.

This should solve the request on issue #15.